### PR TITLE
Remove legacy Slack references

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Requests.
 
 For feature requests, and bugs please use GitHub issues.
 
-Otherwise, use the [GoDaddy OSS Slack](https://godaddy-oss-slack.herokuapp.com/).
-
 ## Testing
 
 Run the tests with:


### PR DESCRIPTION
Contributions and questions should now be handled in GitHub Issues and Discussions.